### PR TITLE
Add theme color scheme for the application

### DIFF
--- a/frontend/src/lib/theme.ts
+++ b/frontend/src/lib/theme.ts
@@ -1,6 +1,29 @@
-import { createTheme, PasswordInput, TextInput } from '@mantine/core'
+import { colorsTuple, createTheme, PasswordInput, TextInput, virtualColor } from '@mantine/core'
 
 export const theme = createTheme({
+  colors: {
+    darkPrimary: colorsTuple('#111111'),
+    darkSecondary: colorsTuple('#1c1c1c'),
+    darkCard: colorsTuple('#232323'),
+    lightPrimary: colorsTuple('#f6f4ef'),
+    lightSecondary: colorsTuple('#fff'),
+    lightCard: colorsTuple('#fff'),
+    primary: virtualColor({
+      name: 'primary',
+      dark: 'darkPrimary',
+      light: 'lightPrimary',
+    }),
+    secondary: virtualColor({
+      name: 'secondary',
+      dark: 'darkSecondary',
+      light: 'lightSecondary',
+    }),
+    card: virtualColor({
+      name: 'card',
+      dark: 'darkCard',
+      light: 'lightCard',
+    }),
+  },
   components: {
     TextInput: TextInput.extend({
       defaultProps: {


### PR DESCRIPTION
## Description
Added a base simple color scheme to the app.
## Proposed changes
Adds dark and light mode variants for primary, secondary and card colors.

## Type of change
- [x] Improvement (change that improves an existing functionality)
- [ ] Feature (New feature to the app)
- [ ] Chore

## Related Issues
Not so much an issue but I did not add the color scheme to any components, due to the way specific components have been setup

- Closes #53 
